### PR TITLE
fix: 캐러셀 스타일링 조정

### DIFF
--- a/app/main/simulation.section.tsx
+++ b/app/main/simulation.section.tsx
@@ -127,7 +127,11 @@ const SimulationSection = () => {
           )}
 
           {/* 캐러셀 콘텐츠 */}
-          <CarouselContent className="mx-auto mt-[59px] max-w-[1440px] gap-x-4 tablet:gap-x-6 tablet:pl-6 web:gap-x-0 web:pl-0">
+          <CarouselContent
+            className={`mx-auto mt-[59px] max-w-[1440px] gap-x-4 web:gap-x-0 web:pl-0 ${
+              isLimitedCarousel ? "tablet:pl-0" : "tablet:gap-x-6 tablet:pl-6"
+            }`}
+          >
             {data?.map((item, i) => (
               <CarouselItem
                 key={i}


### PR DESCRIPTION
### Details
- 디바이스가 웹 환경 사이즈이고  데이터가 3개 미만일 때 캐러셀 패딩 왼쪽 제거하였습니다.