### PR TITLE
fix: Drawer 컴포넌트 분리 및 1:1 상담 버튼 클릭시 drawer 모달 닫기

### DIFF
--- a/app/(GNB-layout)/_components/drawer.tsx
+++ b/app/(GNB-layout)/_components/drawer.tsx
@@ -1,0 +1,55 @@
+import {
+  Drawer,
+  DrawerContent,
+  DrawerFooter,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import Link from "next/link";
+import ActionButtons from "@/components/shared/layout/action-buttons";
+import ExternalLinksNav from "@/components/shared/layout/external-links-nav";
+
+const GNBDrawer = ({
+  open,
+  onOpenChange,
+  isHome,
+  setIsMobileMenuOpen,
+  NAV_LINKS,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isHome: boolean;
+  setIsMobileMenuOpen: (open: boolean) => void;
+  NAV_LINKS: { label: string; path: string }[];
+}) => {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerTitle className="sr-only">메뉴 열기</DrawerTitle>
+      <DrawerContent
+        className={`flex h-full flex-col items-center bg-white ${isHome ? "pt-[67px]" : "pt-12"} font-pretendard`}
+      >
+        <div className="flex flex-1 flex-col items-center justify-center gap-y-[59px]">
+          {NAV_LINKS.map(({ label, path: href }) => (
+            <Link
+              key={href}
+              prefetch={false}
+              href={href}
+              className="h1-m"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+        <DrawerFooter className="flex flex-col justify-center gap-y-[26px] py-10">
+          <ActionButtons
+            className="border-black-1 bg-white text-black hover:border-primary hover:bg-primary"
+            onClick={() => setIsMobileMenuOpen(false)}
+          />
+          <ExternalLinksNav />
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default GNBDrawer;

--- a/components/shared/layout/action-buttons.tsx
+++ b/components/shared/layout/action-buttons.tsx
@@ -8,9 +8,10 @@ import Link from "next/link";
 
 interface ActionButtonsProps {
   className?: string;
+  onClick?: () => void;
 }
 
-const ActionButtons = ({ className }: ActionButtonsProps) => {
+const ActionButtons = ({ className, onClick }: ActionButtonsProps) => {
   const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false);
 
   return (
@@ -20,6 +21,7 @@ const ActionButtons = ({ className }: ActionButtonsProps) => {
           size="lg"
           shape="round"
           className={`border web:w-[160px] ${className}`}
+          onClick={onClick}
         >
           1:1 상담
         </Button>
@@ -28,7 +30,9 @@ const ActionButtons = ({ className }: ActionButtonsProps) => {
       <Button
         size="lg"
         shape="round"
-        onClick={() => setIsSubscriptionModalOpen(true)} //뉴스 레터 모달 띄우기
+        onClick={() => {
+          setIsSubscriptionModalOpen(true);
+        }}
         className={`border web:w-[160px] ${className}`}
       >
         뉴스레터 구독

--- a/components/shared/layout/global-nav-bar.tsx
+++ b/components/shared/layout/global-nav-bar.tsx
@@ -4,12 +4,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, useCallback, useRef, useEffect } from "react";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerFooter,
-  DrawerTitle,
-} from "@/components/ui/drawer";
 import { IconButton, Button } from "@/components/ui/button";
 import {
   TECH_INSIGHT_PAGE,
@@ -20,7 +14,7 @@ import {
 } from "@/constants/path";
 import { SERVICE_NAME } from "@/constants/service";
 import ExternalLinksNav from "@/components/shared/layout/external-links-nav";
-import ActionButtons from "@/components/shared/layout/action-buttons";
+import GNBDrawer from "@/app/(GNB-layout)/_components/drawer";
 import { Share2Icon } from "lucide-react";
 import { shareUrl } from "@/utils/share";
 
@@ -187,31 +181,13 @@ const GlobalNavBar = () => {
           />
         </div>
       </header>
-
-      <Drawer open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
-        <DrawerTitle className="sr-only">메뉴 열기</DrawerTitle>
-        <DrawerContent
-          className={`flex h-full flex-col items-center bg-white ${isHome ? "pt-[67px]" : "pt-12"} font-pretendard`}
-        >
-          <div className="flex flex-1 flex-col items-center justify-center gap-y-[59px]">
-            {NAV_LINKS.map(({ label, path: href }) => (
-              <Link
-                key={href}
-                prefetch={false}
-                href={href}
-                className="h1-m"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                {label}
-              </Link>
-            ))}
-          </div>
-          <DrawerFooter className="flex flex-col justify-center gap-y-[26px] py-10">
-            <ActionButtons className="border-black-1 bg-white text-black hover:border-primary hover:bg-primary" />
-            <ExternalLinksNav />
-          </DrawerFooter>
-        </DrawerContent>
-      </Drawer>
+      <GNBDrawer
+        open={isMobileMenuOpen}
+        onOpenChange={setIsMobileMenuOpen}
+        isHome={isHome}
+        setIsMobileMenuOpen={setIsMobileMenuOpen}
+        NAV_LINKS={NAV_LINKS}
+      />
     </>
   );
 };


### PR DESCRIPTION
### Details
- Drawer UI를 **GNBDrawer**라는 이름의 컴포넌트로 분리 구현
- GNBDrawer에서 `ActionButtons` 컴포넌트를 사용할 때, 1:1 상담 버튼 클릭 시 Drawer가 닫히도록 `onClick` 핸들러 전달.
