### PR TITLE
fix: 랜딩 페이지 시뮬레이션, 아카이브 섹션 데이터 비었을 때 null 처리

### DIFF
--- a/app/main/archive-section.tsx
+++ b/app/main/archive-section.tsx
@@ -25,6 +25,7 @@ const ArchiveSection = () => {
   const onClickPdfDownload = (postId: string) => {
     setSelectedPostId(postId);
   };
+  if (posts.length === 0) return null;
 
   return (
     <section className="px-[16px] py-[80px] tablet:px-[30px] web:px-[120px] web:py-[100px]">

--- a/app/main/simulation.section.tsx
+++ b/app/main/simulation.section.tsx
@@ -59,7 +59,7 @@ const SimulationSection = () => {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  if (!data) return null;
+  if (!data || data.length === 0) return null;
 
   const isLimitedCarousel = (() => {
     if (screenWidth >= 1024) return data.length <= 3;


### PR DESCRIPTION
### Details
- 랜딩 페이지에서 시뮬레이션(DX) 및 아카이브 섹션에 전달되는 데이터가 없을 경우 섹션 자체를 렌더링하지 않도록 조건부 렌더링 적용