### PR TITLE
fix: 랜딩 페이지 히어로 섹션 텍스트 중앙 정렬 및 버튼 인터렉션 스타일링 변경 

### DIFF
--- a/app/(GNB-layout)/_components/drawer.tsx
+++ b/app/(GNB-layout)/_components/drawer.tsx
@@ -37,7 +37,7 @@ const GNBDrawer = ({
               key={href}
               prefetch={false}
               href={href}
-              className="h1-m text-label-strong hover:text-label-alternative active:text-label-strong transition-colors duration-300 ease-in-out"
+              className="text-black transition-colors duration-300 ease-in-out h1-m hover:text-label-alternative active:text-black"
               onClick={() => setIsMobileMenuOpen(false)}
             >
               {label}

--- a/app/main/hero-section.tsx
+++ b/app/main/hero-section.tsx
@@ -8,9 +8,9 @@ const HeroSection = () => {
   const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false);
 
   return (
-    <section className="relative mx-auto min-h-screen w-full max-w-[1440px] px-4 tablet:px-[30px] web:h-[calc(100vh-139px)] web:px-[120px] web:pt-[100px]">
-      <div className="absolute bottom-0 mb-[100px] flex flex-col gap-x-2 text-center text-white ">
-        <h1 className="mb-8 text-left !leading-[140%] text-white gibson-h1-s tablet:gibson-h1-m web:gibson-h1-l">
+    <section className="relative mx-auto flex min-h-screen w-full max-w-[1440px] items-center justify-center px-4 tablet:px-[30px] web:h-[calc(100vh-139px)] web:px-[120px] web:pt-[100px]">
+      <div className=" flex flex-col items-center gap-x-2 text-center text-white">
+        <h1 className="mb-8 !leading-[140%] text-white gibson-h1-m web:gibson-h1-l">
           Global No.1
           <br />
           Digital Twin Platform

--- a/app/main/hero-section.tsx
+++ b/app/main/hero-section.tsx
@@ -17,7 +17,7 @@ const HeroSection = () => {
         </h1>
 
         <ActionButtons
-          className="border-black-1 bg-white text-black hover:border-primary hover:bg-primary"
+          className="border-white bg-transparent text-white hover:bg-white hover:text-black"
           isSubscriptionModalOpen={isSubscriptionModalOpen}
           setIsSubscriptionModalOpen={setIsSubscriptionModalOpen}
         />

--- a/components/shared/layout/action-buttons.tsx
+++ b/components/shared/layout/action-buttons.tsx
@@ -53,7 +53,7 @@ const ActionButtons = ({
   };
 
   return (
-    <div className="flex web:gap-x-3 gap-x-[16px]">
+    <div className="flex gap-x-[16px] web:gap-x-3">
       <Button
         size="lg"
         shape="round"

--- a/components/shared/layout/external-links-nav.tsx
+++ b/components/shared/layout/external-links-nav.tsx
@@ -17,7 +17,7 @@ const ExternalLinksNav = ({ className }: ExternalLinksNavProps) => {
           key={label}
           href={href}
           target={target}
-          className="text-label-normal hover:text-label-alternative active:text-label-strong transition-colors duration-300 ease-in-out"
+          className="text-label-normal transition-colors duration-300 ease-in-out hover:text-label-alternative active:text-black"
         >
           {label}
         </Link>


### PR DESCRIPTION
### Details
- 랜딩 페이지 히어로 섹션 텍스트 중앙 정렬 
- 랜딩 페이지 히어로 섹션 1:1 상담과 뉴스레터 구독 버튼 인터렉션 스타일링 변경
-  tailwind 커스텀 클래스 text-label-strong이 존재하지 않아 text-black으로 일괄 적용